### PR TITLE
Fix Rails startup

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,14 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+amazon:
+  service: S3
+  access_key_id: ""
+  secret_access_key: ""
+  bucket: ""
+  region: "" # e.g. 'eu-central-1'


### PR DESCRIPTION
Rails would not startup if the `config/storage.yml` was missing (even though we don't use ActiveStorage). I added a dummy configuration. Fixes #53 